### PR TITLE
GH-22 Building Blocks of the Application Layer/Ring

### DIFF
--- a/jddd-core/src/main/java/org/jddd/core/annotation/ApplicationService.java
+++ b/jddd-core/src/main/java/org/jddd/core/annotation/ApplicationService.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2020 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jddd.core.annotation;
+
+import java.lang.annotation.*;
+
+/**
+ * Identifies an {@link ApplicationService}.
+ *
+ * @author Christian Stettler
+ * @author Henning Schwentner
+ * @author Stephan Pirnbaum
+ * @author Martin Schimak
+ * @author Oliver Drotbohm
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target(ElementType.TYPE)
+@Documented
+public @interface ApplicationService {
+
+}


### PR DESCRIPTION
Should @ApplicationService reside in org.jddd.core.annotation? Or would org.jddd.core.application.annotation be better?

Closes #22 