### PR TITLE
Static factory methods for Association

### DIFF
--- a/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Association.java
+++ b/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Association.java
@@ -1,5 +1,5 @@
 /*
- * Copyright 2020 the original author or authors.
+ * Copyright 2020-2021 the original author or authors.
  *
  * Licensed under the Apache License, Version 2.0 (the "License");
  * you may not use this file except in compliance with the License.
@@ -27,4 +27,60 @@ package org.jmolecules.ddd.types;
  * @see <a href="https://scabl.blogspot.com/2015/04/aeddd-9.html>John Sullivan - Advancing Enterprise DDD - Reinstating
  *      the Aggregate</a>
  */
-public interface Association<T extends AggregateRoot<T, ID>, ID extends Identifier> extends Identifiable<ID> {}
+public interface Association<T extends AggregateRoot<T, ID>, ID extends Identifier> extends Identifiable<ID> {
+
+	/**
+	 * Creates an {@link Association} pointing to the {@link Identifier} of the given {@link AggregateRoot}.
+	 *
+	 * @param <T> the concrete {@link AggregateRoot} type.
+	 * @param <ID> the concrete {@link Identifier} type.
+	 * @param aggregate must not be {@literal null}.
+	 * @return an {@link Association} pointing to the {@link Identifier} of the given {@link AggregateRoot}, will never be
+	 *         {@literal null}.
+	 * @since 1.2
+	 */
+	static <T extends AggregateRoot<T, ID>, ID extends Identifier> Association<T, ID> forAggregate(T aggregate) {
+
+		if (aggregate == null) {
+			throw new IllegalArgumentException("Aggregate must not be null!");
+		}
+
+		return new SimpleAssociation<>(() -> aggregate.getId());
+	}
+
+	/**
+	 * Creates an {@link Association} pointing to the given {@link Identifier}.
+	 *
+	 * @param <T> the concrete {@link AggregateRoot} type.
+	 * @param <ID> the concrete {@link Identifier} type.
+	 * @param identifier must not be {@literal null}.
+	 * @return an {@link Association} pointing to the given {@link Identifier}, will never be {@literal null}.
+	 * @since 1.2
+	 */
+	static <T extends AggregateRoot<T, ID>, ID extends Identifier> Association<T, ID> forId(ID identifier) {
+
+		if (identifier == null) {
+			throw new IllegalArgumentException("Identifier must not be null!");
+		}
+
+		return new SimpleAssociation<>(() -> identifier);
+	}
+
+	/**
+	 * Returns whether the current {@link Association} points to the same {@link AggregateRoot} as the given one. Unlike
+	 * {@link #equals(Object)} and {@link #hashCode()} that also check for type equality of the {@link Association}
+	 * itself, this only compares the target {@link Identifier} instances.
+	 *
+	 * @param other must not be {@literal null}.
+	 * @return whether the current {@link Association} points to the same {@link AggregateRoot} as the given one.
+	 * @since 1.2
+	 */
+	default boolean pointsToSameAggregateAs(Association<?, ID> other) {
+
+		if (other == null) {
+			throw new IllegalArgumentException("Other association must not be null!");
+		}
+
+		return getId().equals(other.getId());
+	}
+}

--- a/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/SimpleAssociation.java
+++ b/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/SimpleAssociation.java
@@ -1,0 +1,75 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jmolecules.ddd.types;
+
+import java.util.function.Supplier;
+
+/**
+ * @author Oliver Drotbohm
+ */
+class SimpleAssociation<T extends AggregateRoot<T, ID>, ID extends Identifier> implements Association<T, ID> {
+
+	private final Supplier<ID> identifier;
+
+	SimpleAssociation(Supplier<ID> identifier) {
+		this.identifier = identifier;
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see org.jmolecules.ddd.types.Identifiable#getId()
+	 */
+	@Override
+	public ID getId() {
+		return identifier.get();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#toString()
+	 */
+	@Override
+	public String toString() {
+		return getId().toString();
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#equals(java.lang.Object)
+	 */
+	@Override
+	public boolean equals(Object obj) {
+
+		if (obj == this) {
+			return true;
+		}
+
+		if (obj == null || !obj.getClass().equals(this.getClass())) {
+			return false;
+		}
+
+		return ((Association<?, ?>) obj).getId().equals(identifier.get());
+	}
+
+	/*
+	 * (non-Javadoc)
+	 * @see java.lang.Object#hashCode()
+	 */
+	@Override
+	public int hashCode() {
+		return getId().hashCode();
+	}
+}

--- a/jmolecules-ddd/src/test/java/org/jmolecules/ddd/types/AssociationUnitTests.java
+++ b/jmolecules-ddd/src/test/java/org/jmolecules/ddd/types/AssociationUnitTests.java
@@ -1,0 +1,120 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      https://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jmolecules.ddd.types;
+
+import static org.assertj.core.api.Assertions.*;
+
+import org.junit.jupiter.api.Test;
+
+/**
+ * Unit tests for {@link Association}.
+ *
+ * @author Oliver Drotbohm
+ */
+public class AssociationUnitTests {
+
+	@Test // #48
+	void createsAssociationFromIdentifier() {
+
+		SampleIdentifier id = new SampleIdentifier();
+
+		assertThat(Association.forId(id).getId()).isEqualTo(id);
+	}
+
+	@Test // #48
+	void createsAssoctionFromAggregate() {
+
+		SampleIdentifier identifier = new SampleIdentifier();
+		SampleAggregate aggregate = new SampleAggregate(identifier);
+
+		assertThat(Association.forAggregate(aggregate).getId()).isEqualTo(identifier);
+	}
+
+	@Test // #48
+	void rejectsNullIdentifier() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Association.forId(null));
+	}
+
+	@Test // #48
+	void rejectsNullAggregate() {
+		assertThatExceptionOfType(IllegalArgumentException.class).isThrownBy(() -> Association.forAggregate(null));
+	}
+
+	@Test // #48
+	void associationsEqualIfTheyPointToTheSameId() {
+
+		SampleIdentifier identifier = new SampleIdentifier();
+		SampleAggregate aggregate = new SampleAggregate(identifier);
+
+		assertThat(Association.forId(identifier)).isEqualTo(Association.forAggregate(aggregate));
+	}
+
+	@Test // #48
+	void pointsToSameAggregate() {
+
+		SampleIdentifier identifier = new SampleIdentifier();
+		Association<?, SampleIdentifier> simpleAssociation = Association.forId(identifier);
+		SampleAssociation sampleAssociation = new SampleAssociation(identifier);
+
+		assertThat(simpleAssociation.pointsToSameAggregateAs(sampleAssociation));
+		assertThat(sampleAssociation.pointsToSameAggregateAs(simpleAssociation));
+	}
+
+	@Test // #48
+	void rejectsNullReferenceAggregate() {
+
+		assertThatIllegalArgumentException()
+				.isThrownBy(() -> Association.forId(new SampleIdentifier()).pointsToSameAggregateAs(null));
+	}
+
+	static class SampleIdentifier implements Identifier {}
+
+	static class SampleAggregate implements AggregateRoot<SampleAggregate, SampleIdentifier> {
+
+		private final SampleIdentifier id;
+
+		SampleAggregate(SampleIdentifier id) {
+			this.id = id;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.jmolecules.ddd.types.Identifiable#getId()
+		 */
+		@Override
+		public SampleIdentifier getId() {
+			return id;
+		}
+	}
+
+	static class SampleAssociation implements Association<SampleAggregate, SampleIdentifier> {
+
+		SampleIdentifier id;
+
+		public SampleAssociation(SampleIdentifier id) {
+			this.id = id;
+		}
+
+		/*
+		 * (non-Javadoc)
+		 * @see org.jmolecules.ddd.types.Identifiable#getId()
+		 */
+		@Override
+		public SampleIdentifier getId() {
+			return id;
+		}
+	}
+}

--- a/pom.xml
+++ b/pom.xml
@@ -19,6 +19,8 @@
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
+		<assertj.version>3.18.1</assertj.version>
+		<junit.version>5.7.0</junit.version>
 	</properties>
 
 	<licenses>
@@ -104,6 +106,21 @@
 			</distributionManagement>
 		</profile>
 	</profiles>
+	
+	<dependencies>
+		<dependency>
+			<groupId>org.junit.jupiter</groupId>
+			<artifactId>junit-jupiter</artifactId>
+			<version>${junit.version}</version>
+			<scope>test</scope>
+		</dependency>
+		<dependency>
+			<groupId>org.assertj</groupId>
+			<artifactId>assertj-core</artifactId>
+			<version>${assertj.version}</version>
+			<scope>test</scope>
+		</dependency>
+	</dependencies>
 
 	<build>
 


### PR DESCRIPTION
Introduced `Association.forAggregate(…)` and `….forId(…)` to easily create `Association` instances without having to explicitly implement it.