### PR TITLE
GH-51 Better Kotlin integration

### DIFF
--- a/kmolecules-ddd/pom.xml
+++ b/kmolecules-ddd/pom.xml
@@ -53,6 +53,31 @@
                     </execution>
                 </executions>
             </plugin>
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-dependency-plugin</artifactId>
+                <version>3.1.2</version>
+                <executions>
+                    <execution>
+                        <id>unpack</id>
+                        <phase>prepare-package</phase>
+                        <goals>
+                            <goal>unpack</goal>
+                        </goals>
+                        <configuration>
+                            <artifactItems>
+                                <artifactItem>
+                                    <groupId>${project.parent.groupId}</groupId>
+                                    <artifactId>jmolecules-ddd</artifactId>
+                                    <version>${project.parent.version}</version>
+                                    <includes>org/jmolecules/ddd/annotation/*.class</includes>
+                                    <outputDirectory>${project.build.outputDirectory}</outputDirectory>
+                                </artifactItem>
+                            </artifactItems>
+                        </configuration>
+                    </execution>
+                </executions>
+            </plugin>
         </plugins>
     </build>
 

--- a/kmolecules-ddd/pom.xml
+++ b/kmolecules-ddd/pom.xml
@@ -1,0 +1,59 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<project xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+         xmlns="http://maven.apache.org/POM/4.0.0"
+         xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+    <modelVersion>4.0.0</modelVersion>
+
+    <parent>
+        <artifactId>jmolecules</artifactId>
+        <groupId>org.jmolecules</groupId>
+        <version>1.3.0-SNAPSHOT</version>
+    </parent>
+
+    <artifactId>kmolecules-ddd</artifactId>
+
+    <name>kMolecules - DDD</name>
+
+    <properties>
+        <module.name>org.kmolecules.ddd</module.name>
+        <kotlin.version>1.5.0</kotlin.version>
+    </properties>
+
+    <dependencies>
+        <dependency>
+            <groupId>org.jetbrains.kotlin</groupId>
+            <artifactId>kotlin-stdlib</artifactId>
+            <version>${kotlin.version}</version>
+        </dependency>
+    </dependencies>
+
+    <build>
+        <sourceDirectory>${project.basedir}/src/main/kotlin</sourceDirectory>
+        <testSourceDirectory>${project.basedir}/src/test/kotlin</testSourceDirectory>
+        <plugins>
+            <plugin>
+                <groupId>org.jetbrains.kotlin</groupId>
+                <artifactId>kotlin-maven-plugin</artifactId>
+                <version>${kotlin.version}</version>
+
+                <executions>
+                    <execution>
+                        <id>compile</id>
+                        <goals>
+                            <goal>compile</goal>
+                        </goals>
+                    </execution>
+
+                    <execution>
+                        <id>test-compile</id>
+                        <goals>
+                            <goal>test-compile</goal>
+                        </goals>
+                    </execution>
+                </executions>
+            </plugin>
+        </plugins>
+    </build>
+
+</project>

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/AggregateRoot.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/AggregateRoot.kt
@@ -1,0 +1,20 @@
+package org.kmolecules.ddd.types
+
+/**
+ * Identifies an aggregate root, i.e. the root entity of an aggregate. An aggregate forms a cluster of consistent rules
+ * usually formed around a set of entities by defining invariants based on the properties of the aggregate that have to
+ * be met before and after operations on it. Aggregates usually refer to other aggregates by their identifier.
+ * References to aggregate internals should be avoided and at least not considered strongly consistent (i.e. a reference
+ * held could possibly have been gone or become invalid at any point in time). They also act as scope of consistency,
+ * i.e. changes on a single aggregate are expected to be strongly consistent while changes across multiple ones should
+ * only expect eventual consistency.
+ *
+ * Kotlin's counterpart of Java's [AggregateRoot](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/AggregateRoot.java)
+ *
+ * @author Jocelyn Ntakpe
+ * @since 1.3
+ *
+ * See also: [Domain-Driven Design Reference (Evans) - Aggregates](https://domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf)
+ * See also: [John Sullivan - Advancing Enterprise DDD - Reinstating the Aggregate](https://scabl.blogspot.com/2015/04/aeddd-9.html)
+ */
+interface AggregateRoot<T : AggregateRoot<T, ID>, ID : Identifier> : Entity<T, ID>

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Association.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Association.kt
@@ -1,0 +1,55 @@
+package org.kmolecules.ddd.types
+
+/**
+ * An association to an [AggregateRoot].
+ *
+ * Kotlin's counterpart of Java's [Association](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Association.java)
+ *
+ * @author Jocelyn Ntakpe
+ *
+ * See also: [John Sullivan - Advancing Enterprise DDD - Reinstating the Aggregate](https://scabl.blogspot.com/2015/04/aeddd-9.html)
+ */
+interface Association<T : AggregateRoot<T, ID>, ID : Identifier> : Identifiable<ID> {
+
+    companion object {
+
+        /**
+         * Creates an [Association] pointing to the [Identifier] of the given [AggregateRoot].
+         *
+         * @param T the concrete [AggregateRoot] type.
+         * @param ID the concrete [Identifier] type.
+         * @param aggregate used to create the association
+         * @return an [Association] pointing to the [Identifier] of the given [AggregateRoot].
+         * @since 1.3
+         */
+        @JvmStatic
+        fun <T : AggregateRoot<T, ID>, ID : Identifier> forAggregate(aggregate: T): Association<T, ID> {
+            return SimpleAssociation { aggregate.id }
+        }
+
+        /**
+         * Creates an [Association] pointing to the given [Identifier].
+         *
+         * @param T the concrete [AggregateRoot] type.
+         * @param ID the concrete [Identifier] type.
+         * @param identifier used to create the association
+         * @return an [Association] pointing to the given [Identifier].
+         * @since 1.3
+         */
+        @JvmStatic
+        fun <T : AggregateRoot<T, ID>, ID : Identifier> forId(identifier: ID): Association<T, ID> {
+            return SimpleAssociation { identifier }
+        }
+    }
+
+    /**
+     * Returns whether the current [Association] points to the same [AggregateRoot] as the given one. Unlike
+     * [equals] and [hashCode] that also check for type equality of the [Association]
+     * itself, this only compares the target [Identifier] instances.
+     *
+     * @param other association compared with the current instance
+     * @return whether the current [Association] points to the same [AggregateRoot] as the given one.
+     * @since 1.3
+     */
+    fun pointsToSameAggregateAs(other: Association<*, ID>): Boolean = id == other.id
+}

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Entity.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Entity.kt
@@ -1,0 +1,17 @@
+package org.kmolecules.ddd.types
+
+/**
+ * Identifies an [Entity]. Entities represent a thread of continuity and identity, going through a lifecycle,
+ * though their attributes may change. Means of identification may come from the outside, or it may be an arbitrary
+ * identifier created by and for the system, but it must correspond to the identity distinctions in the model. The model
+ * must define what it means to be the same thing.
+ *
+ * Kotlin's counterpart of Java's [Entity](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Entity.java)
+ *
+ * @author Jocelyn Ntakpe
+ * @since 1.3
+ *
+ * See also: [Domain-Driven Design Reference (Evans) - Entities](https://domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf)
+ * See also: [John Sullivan - Advancing Enterprise DDD - Reinstating the Aggregate](https://scabl.blogspot.com/2015/04/aeddd-9.html)
+ */
+interface Entity<T : AggregateRoot<T, *>, ID> : Identifiable<ID>

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Identifiable.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Identifiable.kt
@@ -1,0 +1,17 @@
+package org.kmolecules.ddd.types
+
+/**
+ * An identifiable type, i.e. anything that exposes an [Identifier].
+ *
+ * Kotlin's counterpart of Java's [Identifiable](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Identifiable.java)
+ *
+ * @author Jocelyn Ntakpe
+ * @since 1.3
+ */
+interface Identifiable<ID> {
+
+    /**
+     * Identifier
+     */
+    val id: ID
+}

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Identifier.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Identifier.kt
@@ -1,0 +1,13 @@
+package org.kmolecules.ddd.types
+
+/**
+ * Marker interface for identifiers. Exists primarily to easily identify types that are supposed to be identifiers
+ * within the code base and let the compiler verify the correctness of declared relationships.
+ *
+ * Kotlin's counterpart of Java's [Identifier](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Identifier.java)
+ *
+ * @author Jocelyn Ntakpe
+ * @since 1.3
+ * @see Identifiable
+ */
+interface Identifier

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Repository.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/Repository.kt
@@ -1,0 +1,19 @@
+package org.kmolecules.ddd.types
+
+/**
+ * Identifies a [Repository]. Repositories simulate a collection of aggregates to which aggregate instances can be
+ * added and removed. They usually also expose API to select a subset of aggregates matching certain criteria. Access to
+ * projections of an aggregate might be provided as well but also via a dedicated separate abstraction.
+ *
+ * Implementations use a dedicated persistence mechanism appropriate to the data structure and query requirements at
+ * hand. However, they should make sure that no persistence mechanism specific APIs leak into client code.
+ *
+ * Kotlin's counterpart of Java's [Repository](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/Repository.java)
+ *
+ * @author Jocelyn Ntakpe
+ * @since 1.3
+ * @see [AggregateRoot]
+ *
+ * See also: [Domain-Driven Design Reference (Evans) - Repositories](https://domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf)
+ */
+interface Repository<T : AggregateRoot<T, ID>, ID : Identifier>

--- a/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/SimpleAssociation.kt
+++ b/kmolecules-ddd/src/main/kotlin/org/kmolecules/ddd/types/SimpleAssociation.kt
@@ -1,0 +1,33 @@
+package org.kmolecules.ddd.types
+
+/**
+ * Simple implementation of [Association] to effectively only define [equals] and
+ * [hashCode] on [Association]'s static factory methods.
+ *
+ * Kotlin's equivalent of Java's [SimpleAssociation](https://github.com/xmolecules/jmolecules/blob/main/jmolecules-ddd/src/main/java/org/jmolecules/ddd/types/SimpleAssociation.java)
+ *
+ * @author Jocelyn Ntakpe
+ * @since 1.3
+ * @see Association.forId
+ * @see Association.forAggregate
+ */
+class SimpleAssociation<T : AggregateRoot<T, ID>, ID : Identifier>(private val identifier: () -> ID) : Association<T, ID> {
+
+    override val id: ID
+        get() = identifier()
+
+    override fun equals(other: Any?): Boolean {
+        if (this === other) return true
+        if (javaClass != other?.javaClass) return false
+
+        other as SimpleAssociation<*, *>
+
+        if (id != other.id) return false
+
+        return true
+    }
+
+    override fun hashCode(): Int = id.hashCode()
+
+    override fun toString(): String = id.toString()
+}

--- a/kmolecules-ddd/src/test/kotlin/org/kmolecules/ddd/types/AssociationUnitTests.kt
+++ b/kmolecules-ddd/src/test/kotlin/org/kmolecules/ddd/types/AssociationUnitTests.kt
@@ -1,0 +1,48 @@
+package org.kmolecules.ddd.types
+
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+/**
+ * Unit tests for [Association]
+ *
+ * @author Jocelyn Ntakpe
+ */
+internal class AssociationUnitTests {
+
+    @Test
+    fun `creates association from identifier`() {
+        val id = SampleIdentifier()
+        assertThat(Association.forId<SampleAggregate, SampleIdentifier>(id).id).isEqualTo(id)
+    }
+
+    @Test
+    fun `creates association from aggregate`() {
+        val id = SampleIdentifier()
+        val aggregate = SampleAggregate(id)
+        assertThat(Association.forAggregate(aggregate).id).isEqualTo(id)
+    }
+
+    @Test
+    fun `associations equal if they point to the same id`() {
+        val id = SampleIdentifier()
+        val aggregate = SampleAggregate(id)
+        assertThat(Association.forId<SampleAggregate, SampleIdentifier>(id)).isEqualTo(Association.forAggregate(aggregate))
+        assertThat(Association.forAggregate(aggregate)).isEqualTo(Association.forId<SampleAggregate, SampleIdentifier>(id))
+    }
+
+    @Test
+    fun `points to same aggregate`() {
+        val id = SampleIdentifier()
+        val simpleAssociation: Association<Nothing, SampleIdentifier> = Association.forId(id)
+        val sampleAssociation = SampleAssociation(id)
+        assertThat(simpleAssociation.pointsToSameAggregateAs(sampleAssociation)).isTrue
+        assertThat(sampleAssociation.pointsToSameAggregateAs(simpleAssociation)).isTrue
+    }
+
+    class SampleIdentifier : Identifier
+
+    class SampleAggregate(override val id: SampleIdentifier) : AggregateRoot<SampleAggregate, SampleIdentifier>
+
+    class SampleAssociation(override val id: SampleIdentifier) : Association<SampleAggregate, SampleIdentifier>
+}

--- a/pom.xml
+++ b/pom.xml
@@ -12,10 +12,11 @@
 	<url>https://github.com/xmolecules/jmolecules</url>
 
 	<modules>
-		<module>jmolecules-ddd</module>
-		<module>jmolecules-events</module>
-		<module>jmolecules-architecture</module>
-	</modules>
+        <module>jmolecules-ddd</module>
+        <module>jmolecules-events</module>
+        <module>jmolecules-architecture</module>
+        <module>kmolecules-ddd</module>
+    </modules>
 
 	<properties>
 		<project.build.sourceEncoding>UTF-8</project.build.sourceEncoding>
@@ -106,8 +107,8 @@
 			</distributionManagement>
 		</profile>
 	</profiles>
-	
-	<dependencies>
+
+    <dependencies>
 		<dependency>
 			<groupId>org.junit.jupiter</groupId>
 			<artifactId>junit-jupiter</artifactId>
@@ -137,8 +138,8 @@
 					<target>1.8</target>
 				</configuration>
 			</plugin>
-			
-			<plugin>
+
+            <plugin>
 				<artifactId>maven-jar-plugin</artifactId>
 				<version>3.2.0</version>
 				<configuration>


### PR DESCRIPTION
Fixes #51.

Add improved support for Kotlin allowing to override identifiers via constructors as follows:

```kotlin
class MyEntity(override val id: Id, val other: String): Entity<Aggregate, Id>
```

Using constructors also improve third party libraries support such as Spring Data, Kotlinx.serialization and many more