### PR TITLE
Introduce @Identifier in DDD annotations

### DIFF
--- a/jmolecules-ddd/src/main/java/org/jmolecules/ddd/annotation/Identifier.java
+++ b/jmolecules-ddd/src/main/java/org/jmolecules/ddd/annotation/Identifier.java
@@ -1,0 +1,38 @@
+/*
+ * Copyright 2021 the original author or authors.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ *      http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.jmolecules.ddd.annotation;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+
+/**
+ * Declares a field of a class to constitute the identity of the corresponding class. Primarily used in
+ * {@link AggregateRoot} and {@link Entity} types.
+ *
+ * @author Oliver Drotbohm
+ * @author Stephan Pirnbaum
+ * @author Henning Schwentner
+ * @since 1.3
+ * @see <a href="https://domainlanguage.com/wp-content/uploads/2016/05/DDD_Reference_2015-03.pdf">Domain-Driven Design
+ *      Reference (Evans) - Entities</a>
+ */
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ ElementType.FIELD, ElementType.ANNOTATION_TYPE })
+@Documented
+public @interface Identifier {}


### PR DESCRIPTION
Although not an original concept within the DDD book, an identifier is already part of the type based domain language in the DDD module. For symmetry reasons it's reasonable to also allow to express the concept as annotation. We went for Identifier (over Identity) for the following reasons:

1. Symmetry with the already existing Identifier interface in the type based language.
2. Contrary to the type based approach, the annotation is to be used on a field that *constitutes* the identity of the owner class. It is not the identity itself.