### PR TITLE
Upgrade actions/setup-java from v2 to v1

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -16,16 +16,11 @@ jobs:
     - uses: actions/checkout@v2
 
     - name: Set up JDK 8
-      uses: actions/setup-java@v1
+      uses: actions/setup-java@v2
       with:
+        distribution: 'temurin'
         java-version: 8
-
-    - uses: actions/cache@v1
-      with:
-        path: ~/.m2/repository
-        key: ${{ runner.os }}-maven-${{ hashFiles('**/pom.xml') }}
-        restore-keys: |
-          ${{ runner.os }}-maven-
+        cache: 'maven'
 
     - name: Build with Maven
       run: mvn -B package --file pom.xml


### PR DESCRIPTION
Hey there!

Upgrading `actions/setup-java` from v2 to v1 comes with several benefits, such as built-in caching. I have also set the JDK distribution to use [Eclipse Temurin](https://adoptium.net/faq.html#temurinName) (from Adoptium, the successor of AdoptOpenJDK).

For further information on v1 vs. v2, check out the corresponding [migration guide](https://github.com/actions/setup-java/blob/main/docs/switching-to-v2.md).

Best,
Daniel