### PR TITLE
Link towards Spring Modulith instead of Moduliths in the README

### DIFF
--- a/readme.adoc
+++ b/readme.adoc
@@ -158,7 +158,7 @@ The jMolecules concepts expressed in code can be used to verify rules that stem 
 
 * https://github.com/jqassistant-plugin/jqassistant-jmolecules-plugin[jQAssistant plugin] -- to verify rules applying to the different architectural styles, DDD building blocks, CQRS and events. Also creates PlantUML diagrams from the information available in the codebase.
 * https://github.com/xmolecules/jmolecules-integrations/tree/main/jmolecules-archunit[ArchUnit rules] -- allow to verify relationships between DDD building blocks.
-* https://github.com/odrotbohm/moduliths[Moduliths] -- supports detection of jMolecules components, DDD building blocks and events for module model and documentation purposes (see http://odrotbohm.de/2021/07/moduliths-1.1-released/[blog post] for more information).
+* https://github.com/spring-projects/spring-modulith[Spring Modulith] -- supports detection of jMolecules components, DDD building blocks and events for module model and documentation purposes (see https://docs.spring.io/spring-modulith/docs/current-SNAPSHOT/reference/html/#documentation/ [the Spring Modulith documentation] for more information).
 
 == Installation
 To use jMolecules in your project just declare a dependency to it.


### PR DESCRIPTION
Hello,

I've noticed  in the README that there's a reference to _Moduliths_ instead of _Spring Modulith_.  Since _Moduliths_ has been discontinued in favor of _Spring Modulith_, I think the link should be updated.